### PR TITLE
parse claude

### DIFF
--- a/user_level/CLAUDE.md
+++ b/user_level/CLAUDE.md
@@ -24,6 +24,10 @@
 - `us`: Install/update deps (`uv sync`)
 - `uvrp`: Python with uv (`uv run python`)
 
+### Parse Claude Tools
+- `parse-claude`: Global CLI tool (install with `uv tool install parse-claude`)
+- `uv run python -m parse_claude`: Module usage (legacy)
+
 ### Ruff Analysis (for bulk fixes)
 When dealing with many lint errors, use the global ruff tools:
 ```bash


### PR DESCRIPTION
### TL;DR

Added documentation for Parse Claude Tools in the Claude user guide.

### What changed?

Added a new section titled "Parse Claude Tools" to the CLAUDE.md documentation that explains:
- How to use `parse-claude` as a global CLI tool
- How to install it with `uv tool install parse-claude`
- The legacy module usage method with `uv run python -m parse_claude`

### How to test?

1. Review the updated CLAUDE.md file
2. Verify the Parse Claude Tools section appears between the UV Tools and Ruff Analysis sections
3. Try installing and using the parse-claude tool as described in the documentation

### Why make this change?

To provide clear documentation on how to use the Parse Claude Tools, including both the recommended global CLI approach and the legacy module usage method, making it easier for users to understand the available options.